### PR TITLE
Configure pre-commit with ruff and detect-secrets

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,18 +1,17 @@
 repos:
-  - repo: local
+  - repo: https://github.com/psf/black
+    rev: 25.1.0
     hooks:
       - id: black
-        name: black
-        entry: black
-        language: system
-        types: [python]
+  - repo: https://github.com/pre-commit/mirrors-isort
+    rev: v6.0.0
+    hooks:
       - id: isort
-        name: isort
-        entry: isort
-        language: system
-        types: [python]
-      - id: flake8
-        name: flake8
-        entry: flake8
-        language: system
-        types: [python]
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.4
+    hooks:
+      - id: ruff
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.4.0
+    hooks:
+      - id: detect-secrets

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Adjust limits to fit your hardware.
 ## Development Workflow
 
 1. **Fork → branch → PR** model. Create a feature branch from `main`.
-2. Activate pre‑commit hooks: `pre-commit install`. They run Black, isort, flake8, detect‑secrets.
+2. Activate pre‑commit hooks: `pre-commit install`. They run Black, isort, ruff, detect‑secrets.
 3. Run tests: `pytest`.
 4. Build & run containers locally (`docker compose …`).
 5. Push and open a Pull Request; CI must be green.
@@ -126,7 +126,7 @@ Adjust limits to fit your hardware.
 | ------------------------ | ------------------------------------------ |
 | **Black**                | code formatter                             |
 | **isort**                | import ordering                            |
-| **flake8**               | static analysis                            |
+| **ruff**                 | static analysis                            |
 | **pytest**               | testing                                    |
 | **pre‑commit**           | unified git hooks                          |
 | **Conventional Commits** | commit message style (`feat: …`, `fix: …`) |

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 black
 isort
-flake8
+ruff
+detect-secrets
 pre-commit
 pytest


### PR DESCRIPTION
## Summary
- integrate `ruff`, `isort` and `detect-secrets` hooks
- update dev requirements
- document new hooks in README

## Testing
- `pre-commit run --files README.md requirements-dev.txt .pre-commit-config.yaml` *(fails: `pre-commit: command not found`)*
- `pytest -q` *(fails: `pytest: command not found`)*