### PR TITLE
Fix isort rev for pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/mirrors-isort
-    rev: 6.0.1
+    rev: v5.13.2
     hooks:
       - id: isort
   - repo: https://github.com/astral-sh/ruff-pre-commit


### PR DESCRIPTION
## Summary
- point isort pre-commit hook to a valid release tag

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*
- `pip install pytest` *(fails: No route to host)*