### PR TITLE
Simplify tooling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,5 @@
 repos:
-  - repo: https://github.com/psf/black
-    rev: 25.1.0
-    hooks:
-      - id: black
-  - repo: https://github.com/pre-commit/mirrors-isort
-    rev: 6.0.1
-    hooks:
-      - id: isort
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.10
     hooks:
       - id: ruff
-  - repo: https://github.com/Yelp/detect-secrets
-    rev: v1.5.0
-    hooks:
-      - id: detect-secrets

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Adjust limits to fit your hardware.
 ## Development Workflow
 
 1. **Fork → branch → PR** model. Create a feature branch from `main`.
-2. Activate pre‑commit hooks: `pre-commit install`. They run Black, isort, ruff, detect‑secrets.
+2. Activate pre‑commit hooks: `pre-commit install`. They run ruff.
 3. Run tests: `pytest`.
 4. Build & run containers locally (`docker compose …`).
 5. Push and open a Pull Request; CI must be green.
@@ -124,8 +124,6 @@ Adjust limits to fit your hardware.
 
 | Tool                     | Purpose                                    |
 | ------------------------ | ------------------------------------------ |
-| **Black**                | code formatter                             |
-| **isort**                | import ordering                            |
 | **ruff**                 | static analysis                            |
 | **pytest**               | testing                                    |
 | **pre‑commit**           | unified git hooks                          |

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,3 @@
-black
-isort
 ruff
-detect-secrets
 pre-commit
 pytest


### PR DESCRIPTION
## Summary
- drop Black, isort and detect-secrets from dev tooling
- keep Ruff only in pre-commit
- update docs

## Testing
- `ruff check .`
- `pytest -q` *(fails: `pytest: command not found`)*
- `pre-commit run --files README.md requirements-dev.txt .pre-commit-config.yaml` *(fails: `pre-commit: command not found`)*