### PR TITLE
Add ccxt client and exchange config

### DIFF
--- a/app/etl/__init__.py
+++ b/app/etl/__init__.py
@@ -1,0 +1,3 @@
+from .ccxt_client import get_exchange
+
+__all__ = ["get_exchange"]

--- a/app/etl/ccxt_client.py
+++ b/app/etl/ccxt_client.py
@@ -1,0 +1,31 @@
+"""Thin wrapper around ccxt to create rate-limited exchange clients."""
+
+from __future__ import annotations
+
+import importlib
+
+
+_DEF_OPTIONS = {
+    "enableRateLimit": True,
+    "timeout": 30_000,
+    "options": {"adjustForTimeDifference": True},
+}
+
+
+def get_exchange(name: str):
+    """Return an instantiated ccxt exchange.
+
+    Parameters
+    ----------
+    name:
+        Exchange id as used in `ccxt`.
+
+    Returns
+    -------
+    ccxt.Exchange
+        Configured exchange instance.
+    """
+    ccxt = importlib.import_module("ccxt")
+    cls = getattr(ccxt, name)
+    exchange = cls(_DEF_OPTIONS)
+    return exchange

--- a/configs/config.schema.yaml
+++ b/configs/config.schema.yaml
@@ -1,7 +1,7 @@
 $schema: "https://json-schema.org/draft/2020-12/schema"
 title: Quant Agent Platform – config schema
 type: object
-required: [sandbox, metrics]
+required: [sandbox, metrics, exchanges]
 
 properties:
   sandbox:
@@ -37,3 +37,17 @@ properties:
       psr_min:
         type: number
         minimum: 0
+
+  exchanges:
+    type: array
+    items:
+      type: object
+      required: [id, rate_limit, enable_spot]
+      properties:
+        id:
+          type: string
+        rate_limit:
+          type: integer
+          minimum: 1
+        enable_spot:
+          type: boolean

--- a/configs/config.yml
+++ b/configs/config.yml
@@ -10,3 +10,11 @@ metrics:
   sortino_min: 2.0
   calmar_min: 0.5
   psr_min: 0.55
+
+exchanges:
+  - id: binance
+    rate_limit: 200      # ms
+    enable_spot: true
+  - id: coinbasepro
+    rate_limit: 350
+    enable_spot: true

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -41,7 +41,8 @@ RUN pip install --no-cache-dir --upgrade pip && \
         polars==1.29.* \
         qdrant-client==1.14.* \
         'httpx[http2]>=0.28,<1.0' \
-        pydantic==2.*
+        pydantic==2.* \
+        'ccxt[pro]'
 
 # ---------------------------------------------------------------------------
 # 4. Workdir & permissions

--- a/tests/test_ccxt_client.py
+++ b/tests/test_ccxt_client.py
@@ -1,0 +1,35 @@
+import sys
+from types import ModuleType
+
+# ruff: noqa: E402
+
+import pytest
+
+
+# create a fake ccxt module with one exchange class
+class FakeExchange:
+    def __init__(self, opts):
+        self.options = opts
+
+    def ping(self):
+        return 'pong'
+
+
+class FakeCCXT(ModuleType):
+    binance = FakeExchange
+
+
+sys.modules['ccxt'] = FakeCCXT('ccxt')
+
+from app.etl.ccxt_client import get_exchange
+
+
+def test_get_exchange_returns_instance():
+    ex = get_exchange('binance')
+    assert isinstance(ex, FakeExchange)
+    assert ex.options['timeout'] == 30_000
+
+
+def test_get_exchange_unknown_raises():
+    with pytest.raises(AttributeError):
+        get_exchange('nosuch')

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -22,9 +22,16 @@ class MetricsCfg(BaseModel):
     psr_min: float = Field(gt=0)
 
 
+class ExchangeCfg(BaseModel):
+    id: str
+    rate_limit: int = Field(gt=0)
+    enable_spot: bool
+
+
 class Config(BaseModel):
     sandbox: SandboxCfg
     metrics: MetricsCfg
+    exchanges: list[ExchangeCfg]
 
 
 # ---------- Helpers ----------
@@ -52,12 +59,14 @@ def test_valid_config():
     assert cfg.metrics.sharpe_min >= 1.0
     assert cfg.metrics.sortino_min >= 1.0
     assert cfg.sandbox.cpu_limit <= 2
+    assert any(ex.id == "binance" for ex in cfg.exchanges)
 
 
 def test_invalid_config_raises():
     broken = {
         "sandbox": {"cpu_limit": 0, "memory_limit_mb": 128, "disk_limit_mb": 10, "network": False},
         "metrics": {"sharpe_min": -1, "sortino_min": 0, "calmar_min": 0, "psr_min": 0},
+        "exchanges": [{"id": "binance", "rate_limit": -1, "enable_spot": True}],
     }
     with pytest.raises(ValidationError):
         Config.model_validate(broken)


### PR DESCRIPTION
## Summary
- add exchange section to config and schema
- create ccxt client helper
- include ccxt in Dockerfile
- extend config tests and add ccxt_client tests

## Testing
- `ruff check .`
- `pytest -q` *(fails: command not found)*